### PR TITLE
Some indicative tests for TransactionManager

### DIFF
--- a/NetGain.Test/NetGain.Test.csproj
+++ b/NetGain.Test/NetGain.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RelationshipTests.cs" />
     <Compile Include="LabelTests.cs" />
+    <Compile Include="TransactionManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetGain\NetGain.csproj">

--- a/NetGain.Test/TransactionManagerTests.cs
+++ b/NetGain.Test/TransactionManagerTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NetGain.Transaction;
+
+
+namespace NetGain.Test
+{
+    [TestClass]
+    public class TransactionManagerTests
+    {
+        [TestMethod]
+        public void TestTransactionManager_Delete()
+        {
+            // Arrange
+            CreateMoveNode(new Movie { released = 2015, tagline = "Ultron lives!", title = "Avengers: Age of Ultron" });
+            CreateMoveNode(new Movie { released = 2013, tagline = "Avengers", title = "Marvel's The Avengers" });
+
+            // Act
+            DeleteAllRelationshipsAndNodes();
+
+            // Assert
+            var txMgr = new TransactionManager();
+            var stmt = new Statement {statement = "Match (n:Movie) return n"};
+            var tx = txMgr.Begin(new[] {stmt});
+            var data = (dynamic)tx.results[0].data;
+            
+            Assert.AreEqual(0, data.Count);
+        }
+
+        [TestMethod]
+        public void TestTransactionManager_MatchNReturnN_ShouldReturnAllNodes()
+        {
+            // Arrange
+            DeleteAllRelationshipsAndNodes();
+
+            CreateMoveNode(new Movie { released = 2015, tagline = "Ultron lives!", title = "Avengers: Age of Ultron" });
+            CreateMoveNode(new Movie { released = 2013, tagline = "Avengers", title = "Marvel's The Avengers" });
+            var txMgr = new TransactionManager();
+            var stmt = new Statement { statement = "Match (n:Movie) return n" };
+
+            // Act
+            var tx = txMgr.Begin(new[] {stmt});
+
+            // Assert
+            var data = (dynamic) tx.results[0].data;
+            Assert.AreEqual(2, data.Count);
+            Assert.AreEqual(2015, data[0].row[0].released.Value);
+            Assert.AreEqual(2013, data[1].row[0].released.Value);
+        }
+
+        [TestMethod]
+        public void TestTransactionManager_StatementWithParams_ShouldExecuteSuccessfully()
+        {
+            // Arrange
+            DeleteAllRelationshipsAndNodes();
+
+            var txMgr = new TransactionManager();
+            var parm = new Parameter {props = new List<dynamic> {new {title = "The Matrix", released = 1999}}};
+            var stmt = new Statement {statement = "CREATE (n:Movie {props}) return n", parameters = parm};
+
+            // Act
+            var tx = txMgr.Begin(new[] { stmt });
+            txMgr.Commit(tx);
+
+            // Assert
+            var data = ReadAllMovieNodes();
+
+            Assert.AreEqual(1, data.Count);
+            Assert.AreEqual(1999, data[0].row[0].released.Value);
+            Assert.AreEqual("The Matrix", data[0].row[0].title.Value);
+        }
+
+        private static dynamic ReadAllMovieNodes()
+        {
+            var txMgr = new TransactionManager();
+            var stmt = new Statement {statement = "Match (n:Movie) return n"};
+            var tx = txMgr.Begin(new[] {stmt});
+
+            dynamic data = tx.results[0].data;
+            return data;
+        }
+
+        private static void DeleteAllRelationshipsAndNodes()
+        {
+            var txMgr = new TransactionManager();
+            var deleteRelationshipsStatement = new Statement {statement = "MATCH ()-[r]-() DELETE r"};
+            var deleteNodesStatement = new Statement {statement = "MATCH (n) DELETE n"};
+            var deleteTx = txMgr.Begin(new[] {deleteRelationshipsStatement, deleteNodesStatement});
+            txMgr.Commit(deleteTx);
+        }
+
+        private static void CreateMoveNode(Movie movie)
+        {
+            var nodeProvider1 = new NodeProvider();
+            var labelProvider1 = new LabelProvider();
+            var movie1 = movie;
+            var node1 = nodeProvider1.Create(movie1);
+            labelProvider1.Add(node1, "Movie");
+        }
+    }
+}
+

--- a/NetGain/Transaction/TransactionManager.cs
+++ b/NetGain/Transaction/TransactionManager.cs
@@ -55,7 +55,8 @@ namespace NetGain.Transaction
 			if (transaction != null)
 			{
 				DateTime tryResult;
-				if (DateTime.TryParse(transaction.expires, out tryResult))
+			    string expires = transaction.expires ?? "";
+			    if (!string.IsNullOrEmpty(expires) && DateTime.TryParse(expires, out tryResult))
 				{
 					result = tryResult;
 				}


### PR DESCRIPTION
Hello,

I'm glad to find an already existing library that simply wraps the transactional endpoint and allows you to use straight cypher.  I'm hoping to incorporate this in one of our applications - we wrote our own wrapper over the rest endpoint.

In this pull request I added some tests for TransactionManager as a way of documenting how to use it. I hope to add a few more instances, especially converting the result into a Movie node. 

Also, when I first ran the NetGainConsole application I got an error in TransactionManager trying to parse out the "Expires" field - it looked like .NET couldn't evaluate what overload to call, so I cast the source field to string and it solved it.

Regards,
Peter
